### PR TITLE
Add Llama API Support

### DIFF
--- a/config/examples/llamaapi-llama-4-Maverick-17B-128E-Instruct-FP8.yaml
+++ b/config/examples/llamaapi-llama-4-Maverick-17B-128E-Instruct-FP8.yaml
@@ -1,0 +1,5 @@
+llm:
+  api_type: llamaapi
+  base_url: "https://api.llama.com/compat/v1/"
+  api_key: "YOUR_API_KEY"
+  model: llama-4-Maverick-17B-128E-Instruct-FP8

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -43,6 +43,7 @@ class LLMType(Enum):
     OPENROUTER_REASONING = "openrouter_reasoning"
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
+    LLAMA_API = "llama_api"
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -52,6 +52,7 @@ from metagpt.utils.token_counter import (
         LLMType.DEEPSEEK,
         LLMType.SILICONFLOW,
         LLMType.OPENROUTER,
+        LLMType.LLAMA_API,
     ]
 )
 class OpenAILLM(BaseLLM):

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -113,6 +113,10 @@ TOKEN_COSTS = {
     "doubao-pro-128k-240515": {"prompt": 0.0007, "completion": 0.0013},
     "llama3-70b-llama3-70b-instruct": {"prompt": 0.0, "completion": 0.0},
     "llama3-8b-llama3-8b-instruct": {"prompt": 0.0, "completion": 0.0},
+    "llama-4-Scout-17B-16E-Instruct-FP8" : {"prompt": 0.0, "completion": 0.0}, # start, for Llama API
+    "llama-4-Maverick-17B-128E-Instruct-FP8": {"prompt": 0.0, "completion": 0.0},
+    "llama-3.3-8B-Instruct": {"prompt": 0.0, "completion": 0.0},
+    "llama-3.3-70B-Instruct": {"prompt": 0.0, "completion": 0.0}, # end, for Llama API
 }
 
 


### PR DESCRIPTION
**Features**
The changes in the PR are to add Llama API support with the openai spec compat endpoint.

This includes the support for the following models:
- llama-4-Scout-17B-16E-Instruct-FP8
- llama-4-Maverick-17B-128E-Instruct-FP8
- llama-3.3-8B-Instruct
- llama-3.3-70B-Instruct
    
**I'm unable to run because of the issue here: https://github.com/FoundationAgents/MetaGPT/issues/1819**


**Feature Docs**
- TODO


**Result**
- TODO

**Other**
<!-- Something else about this PR. -->