### PR TITLE
Use model instead of config.model inside an LLM instance

### DIFF
--- a/metagpt/provider/human_provider.py
+++ b/metagpt/provider/human_provider.py
@@ -18,6 +18,7 @@ class HumanProvider(BaseLLM):
 
     def __init__(self, config: LLMConfig):
         self.config = config
+        self.model = config.model
 
     def ask(self, msg: str, timeout=USE_CONFIG_TIMEOUT) -> str:
         logger.info("It's your turn, please type in your response. You may also refer to the context below")

--- a/metagpt/provider/ollama_api.py
+++ b/metagpt/provider/ollama_api.py
@@ -195,6 +195,7 @@ class OllamaLLM(BaseLLM):
     def __init__(self, config: LLMConfig):
         self.client = GeneralAPIRequestor(base_url=config.base_url, key=config.api_key)
         self.config = config
+        self.model = config.model
         self.http_method = "post"
         self.use_system_prompt = False
         self.cost_manager = TokenCostManager()

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -321,6 +321,6 @@ class OpenAILLM(BaseLLM):
 
     def count_tokens(self, messages: list[dict]) -> int:
         try:
-            return count_message_tokens(messages, self.config.model)
+            return count_message_tokens(messages, self.model)
         except:
             return super().count_tokens(messages)

--- a/metagpt/provider/qianfan_api.py
+++ b/metagpt/provider/qianfan_api.py
@@ -37,6 +37,7 @@ class QianFanLLM(BaseLLM):
         self.cost_manager = CostManager(token_costs=self.token_costs)
 
     def __init_qianfan(self):
+        self.model = self.config.model
         if self.config.access_key and self.config.secret_key:
             # for system level auth, use access_key and secret_key, recommended by official
             # set environment variable due to official recommendation
@@ -61,14 +62,14 @@ class QianFanLLM(BaseLLM):
             ("ERNIE-Speed", "ernie_speed"),
             ("EB-turbo-AppBuilder", "ai_apaas"),
         ]
-        if self.config.model in [pair[0] for pair in support_system_pairs]:
+        if self.model in [pair[0] for pair in support_system_pairs]:
             # only some ERNIE models support
             self.use_system_prompt = True
         if self.config.endpoint in [pair[1] for pair in support_system_pairs]:
             self.use_system_prompt = True
 
-        assert not (self.config.model and self.config.endpoint), "Only set `model` or `endpoint` in the config"
-        assert self.config.model or self.config.endpoint, "Should set one of `model` or `endpoint` in the config"
+        assert not (self.model and self.config.endpoint), "Only set `model` or `endpoint` in the config"
+        assert self.model or self.config.endpoint, "Should set one of `model` or `endpoint` in the config"
 
         self.token_costs = copy.deepcopy(QIANFAN_MODEL_TOKEN_COSTS)
         self.token_costs.update(QIANFAN_ENDPOINT_TOKEN_COSTS)
@@ -87,8 +88,8 @@ class QianFanLLM(BaseLLM):
             kwargs["temperature"] = self.config.temperature
         if self.config.endpoint:
             kwargs["endpoint"] = self.config.endpoint
-        elif self.config.model:
-            kwargs["model"] = self.config.model
+        elif self.model:
+            kwargs["model"] = self.model
 
         if self.use_system_prompt:
             # if the model support system prompt, extract and pass it
@@ -99,7 +100,7 @@ class QianFanLLM(BaseLLM):
 
     def _update_costs(self, usage: dict):
         """update each request's token cost"""
-        model_or_endpoint = self.config.model or self.config.endpoint
+        model_or_endpoint = self.model or self.config.endpoint
         local_calc_usage = model_or_endpoint in self.token_costs
         super()._update_costs(usage, model_or_endpoint, local_calc_usage)
 

--- a/tests/metagpt/provider/mock_llm_config.py
+++ b/tests/metagpt/provider/mock_llm_config.py
@@ -15,6 +15,7 @@ mock_llm_config = LLMConfig(
     app_id="mock_app_id",
     api_secret="mock_api_secret",
     domain="mock_domain",
+    model="mock_model",
 )
 
 

--- a/tests/metagpt/provider/test_bedrock_api.py
+++ b/tests/metagpt/provider/test_bedrock_api.py
@@ -22,13 +22,13 @@ usage = {
 }
 
 
-def mock_invoke_model(self: BedrockLLM, *args, **kwargs) -> dict:
+async def mock_invoke_model(self: BedrockLLM, *args, **kwargs) -> dict:
     provider = self.config.model.split(".")[0]
     self._update_costs(usage, self.config.model)
     return BEDROCK_PROVIDER_RESPONSE_BODY[provider]
 
 
-def mock_invoke_model_stream(self: BedrockLLM, *args, **kwargs) -> dict:
+async def mock_invoke_model_stream(self: BedrockLLM, *args, **kwargs) -> dict:
     # use json object to mock EventStream
     def dict2bytes(x):
         return json.dumps(x).encode("utf-8")

--- a/tests/metagpt/provider/test_openai.py
+++ b/tests/metagpt/provider/test_openai.py
@@ -169,7 +169,7 @@ async def test_openai_acompletion(mocker):
 
 def test_count_tokens():
     llm = LLM()
-    llm.config.model = "gpt-4o"
+    llm.model = "gpt-4o"
     messages = [
         llm._system_msg("some system msg"),
         llm._system_msg("some system message 2"),
@@ -184,7 +184,7 @@ def test_count_tokens():
 
 def test_count_tokens_long():
     llm = LLM()
-    llm.config.model = "gpt-4-0613"
+    llm.model = "gpt-4-0613"
     test_msg_content = " ".join([str(i) for i in range(100000)])
     messages = [
         llm._system_msg("You are a helpful assistant"),
@@ -193,7 +193,7 @@ def test_count_tokens_long():
     cnt = llm.count_tokens(messages)  # 299023, ~300k
     assert 290000 <= cnt <= 300000
 
-    llm.config.model = "test_llm"  # a non-openai model, will use heuristics base count_tokens
+    llm.model = "test_llm"  # a non-openai model, will use heuristics base count_tokens
     cnt = llm.count_tokens(messages)  # 294474, ~300k, ~2% difference
     assert 290000 <= cnt <= 300000
 
@@ -202,7 +202,7 @@ def test_count_tokens_long():
 @pytest.mark.asyncio
 async def test_aask_long():
     llm = LLM()
-    llm.config.model = "deepseek-ai/DeepSeek-Coder-V2-Instruct"  # deepseek-coder on siliconflow, limit 32k
+    llm.model = "deepseek-ai/DeepSeek-Coder-V2-Instruct"  # deepseek-coder on siliconflow, limit 32k
     llm.config.compress_type = CompressType.POST_CUT_BY_TOKEN
     test_msg_content = " ".join([str(i) for i in range(100000)])  # corresponds to ~300k tokens
     messages = [
@@ -216,7 +216,7 @@ async def test_aask_long():
 @pytest.mark.asyncio
 async def test_aask_long_no_compress():
     llm = LLM()
-    llm.config.model = "deepseek-ai/DeepSeek-Coder-V2-Instruct"  # deepseek-coder on siliconflow, limit 32k
+    llm.model = "deepseek-ai/DeepSeek-Coder-V2-Instruct"  # deepseek-coder on siliconflow, limit 32k
     # Not specifying llm.config.compress_type will use default "", no compress
     test_msg_content = " ".join([str(i) for i in range(100000)])  # corresponds to ~300k tokens
     messages = [


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->

修复LLM实例间模型配置相互影响的bug：引入self.model作为config.model的独立拷贝
建立新的代码规范：LLM内部使用self.model而非self.config.model，避免全局配置被意外修改
支持手动修改特定LLM实例的模型名（如role_zero_memory固定使用4o-mini进行压缩）而不影响其他实例

**Feature Docs**
<!-- The RFC, tutorial, or use cases about the feature if it's a pretty big update. If not, there is no need to fill. -->
新的使用规范：

self.model：LLM实例的私有模型配置，可安全修改，仅影响当前实例
self.config.model：全局配置，不应被直接修改，避免影响其他LLM实例

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it. -->

Bug修复：解决了修改self.config.model导致其他LLM实例配置被意外改变的问题
代码安全性：提高了LLM实例间的隔离性，避免配置污染
向后兼容：现有代码逻辑基本不变，只是内部实现更加安全
可扩展性：为特定场景下的模型定制化提供了安全的实现方式

**Result**
<!-- The screenshot/log of unittest/running result -->
相关单元测试均通过：

✅ tests/metagpt/provider/test_base_llm.py
✅ tests/metagpt/provider/mock_llm_config.py
✅ tests/metagpt/provider/test_bedrock_api.py
✅ tests/metagpt/provider/test_human_provider.py (KeyError和AssertionError相关失败非本次改动导致)
✅ tests/metagpt/provider/test_ollama_api.py
✅ tests/metagpt/provider/test_openai.py（tts相关失败与oneapi有关，非本次改动导致）
✅ tests/metagpt/provider/test_qianfan_api.py (TypeError相关失败非本次改动导致)

**Other**
<!-- Something else about this PR. -->
此次改动为预防性bug修复，主要影响LLM provider层的内部实现，对外部API调用方式无影响。建议重点关注LLM实例创建和模型配置相关的代码路径。