### PR TITLE
Allow a team without leader

### DIFF
--- a/metagpt/environment/mgx/mgx_env.py
+++ b/metagpt/environment/mgx/mgx_env.py
@@ -27,10 +27,17 @@ class MGXEnv(Environment, SerializationMixin):
 
         tl = self.get_role(TEAMLEADER_NAME)  # TeamLeader's name is Mike
 
+        # If there is no TeamLeader in the environment, fall back to the regular publishing flow
+        if tl is None:
+            self._publish_message(message)
+            self.history.add(message)
+            return True
+
         if user_defined_recipient:
             # human user's direct chat message to a certain role
             for role_name in message.send_to:
-                if self.get_role(role_name).is_idle:
+                role_obj = self.get_role(role_name)
+                if role_obj and role_obj.is_idle:
                     # User starts a new direct chat with a certain role, expecting a direct chat response from the role; Other roles including TL should not be involved.
                     # If the role is not idle, it means the user helps the role with its current work, in this case, we handle the role's response message as usual.
                     self.direct_chat_roles.add(role_name)


### PR DESCRIPTION
**Features**
<!-- Clear and direct description of the submit features. -->
<!-- If it's a bug fix, please also paste the issue link. -->
This change will allow a team without a leader, so it fixes the error in the multi-agent example: https://github.com/FoundationAgents/MetaGPT/issues/1888

**Influence**
<!-- Tell me the impact of the new feature and I'll focus on it.  -->
Newcomers may become discouraged when they encounter a crash in the early example in the tutorial. This fix will enable new users of this project to proceed and utilize the project/library/app.

**Result**
<!-- The screenshot/log of unittest/running result -->
<img width="1917" height="929" alt="Screenshot from 2025-09-28 06-20-39" src="https://github.com/user-attachments/assets/819bf3fa-2ec2-44dc-9012-e33ced3629b6" />

**Other**
<!-- Something else about this PR. -->
The fix can also be done by simply adding a leader to the example code, but we already have several PR that go that way, and none have been approved.