### PR TITLE
feat: add Avian as an LLM provider

### DIFF
--- a/config/examples/avian-deepseek-v3.2.yaml
+++ b/config/examples/avian-deepseek-v3.2.yaml
@@ -1,0 +1,10 @@
+llm:
+  api_type: avian
+  base_url: "https://api.avian.io/v1"
+  api_key: "YOUR_API_KEY"
+  model: "deepseek/deepseek-v3.2"
+  # Available models:
+  #   deepseek/deepseek-v3.2  - 164K context, $0.26/$0.38 per 1M tokens
+  #   moonshotai/kimi-k2.5    - 131K context, $0.45/$2.20 per 1M tokens
+  #   z-ai/glm-5              - 131K context, $0.30/$2.55 per 1M tokens
+  #   minimax/minimax-m2.5    - 1M context,   $0.30/$1.10 per 1M tokens

--- a/metagpt/configs/llm_config.py
+++ b/metagpt/configs/llm_config.py
@@ -44,6 +44,7 @@ class LLMType(Enum):
     BEDROCK = "bedrock"
     ARK = "ark"  # https://www.volcengine.com/docs/82379/1263482#python-sdk
     LLAMA_API = "llama_api"
+    AVIAN = "avian"
 
     def __missing__(self, key):
         return self.OPENAI

--- a/metagpt/provider/openai_api.py
+++ b/metagpt/provider/openai_api.py
@@ -53,6 +53,7 @@ from metagpt.utils.token_counter import (
         LLMType.SILICONFLOW,
         LLMType.OPENROUTER,
         LLMType.LLAMA_API,
+        LLMType.AVIAN,
     ]
 )
 class OpenAILLM(BaseLLM):

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -117,6 +117,10 @@ TOKEN_COSTS = {
     "llama-4-Maverick-17B-128E-Instruct-FP8": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-8B-Instruct": {"prompt": 0.0, "completion": 0.0},
     "llama-3.3-70B-Instruct": {"prompt": 0.0, "completion": 0.0},  # end, for Llama API
+    "deepseek/deepseek-v3.2": {"prompt": 0.00026, "completion": 0.00038},  # start, for Avian
+    "moonshotai/kimi-k2.5": {"prompt": 0.00045, "completion": 0.0022},
+    "z-ai/glm-5": {"prompt": 0.0003, "completion": 0.00255},
+    "minimax/minimax-m2.5": {"prompt": 0.0003, "completion": 0.0011},  # end, for Avian
 }
 
 
@@ -350,6 +354,10 @@ TOKEN_MAX = {
     "qwen-7b-chat": 32000,
     "qwen-1.8b-longcontext-chat": 32000,
     "qwen-1.8b-chat": 8000,
+    "deepseek/deepseek-v3.2": 164000,  # start, for Avian
+    "moonshotai/kimi-k2.5": 131000,
+    "z-ai/glm-5": 131000,
+    "minimax/minimax-m2.5": 1000000,  # end, for Avian
 }
 
 # For Amazon Bedrock US region

--- a/tests/metagpt/provider/mock_llm_config.py
+++ b/tests/metagpt/provider/mock_llm_config.py
@@ -72,3 +72,10 @@ mock_llm_config_bedrock = LLMConfig(
 )
 
 mock_llm_config_ark = LLMConfig(api_type="ark", api_key="eyxxx", base_url="xxx", model="ep-xxx")
+
+mock_llm_config_avian = LLMConfig(
+    api_type="avian",
+    api_key="avian-mock-key",
+    base_url="https://api.avian.io/v1",
+    model="deepseek/deepseek-v3.2",
+)

--- a/tests/metagpt/provider/test_avian_api.py
+++ b/tests/metagpt/provider/test_avian_api.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2026/2/27
+@Author  : avianion
+@File    : test_avian_api.py
+@Desc    : Tests for Avian LLM provider (OpenAI-compatible)
+"""
+
+import pytest
+from openai.types.chat import ChatCompletionChunk
+
+from metagpt.configs.llm_config import LLMType
+from metagpt.provider.llm_provider_registry import create_llm_instance
+from metagpt.provider.openai_api import OpenAILLM
+from tests.metagpt.provider.mock_llm_config import mock_llm_config_avian
+from tests.metagpt.provider.req_resp_const import (
+    get_openai_chat_completion,
+    get_openai_chat_completion_chunk,
+    llm_general_chat_funcs_test,
+    messages,
+    prompt,
+    resp_cont_tmpl,
+)
+
+name = "Avian assistant"
+resp_cont = resp_cont_tmpl.format(name=name)
+default_resp = get_openai_chat_completion(name)
+default_resp_chunk = get_openai_chat_completion_chunk(name, usage_as_dict=True)
+
+
+class TestAvianProvider:
+    def test_avian_llm_type_exists(self):
+        """Verify that the AVIAN LLMType enum value exists."""
+        assert LLMType.AVIAN.value == "avian"
+
+    def test_avian_registered_as_openai_compatible(self):
+        """Verify Avian is registered and creates an OpenAILLM instance."""
+        llm = create_llm_instance(mock_llm_config_avian)
+        assert isinstance(llm, OpenAILLM)
+
+    def test_avian_client_kwargs(self):
+        """Verify that Avian client kwargs are correctly configured."""
+        instance = OpenAILLM(mock_llm_config_avian)
+        kwargs = instance._make_client_kwargs()
+        assert kwargs["api_key"] == "avian-mock-key"
+        assert kwargs["base_url"] == "https://api.avian.io/v1"
+        assert "http_client" not in kwargs
+
+    def test_avian_model_set(self):
+        """Verify the model name is correctly set on the instance."""
+        instance = OpenAILLM(mock_llm_config_avian)
+        assert instance.model == "deepseek/deepseek-v3.2"
+
+
+async def mock_avian_acompletions_create(self, stream: bool = False, **kwargs) -> ChatCompletionChunk:
+    if stream:
+
+        class Iterator(object):
+            async def __aiter__(self):
+                yield default_resp_chunk
+
+        return Iterator()
+    else:
+        return default_resp
+
+
+@pytest.mark.asyncio
+async def test_avian_acompletion(mocker):
+    mocker.patch("openai.resources.chat.completions.AsyncCompletions.create", mock_avian_acompletions_create)
+
+    llm = OpenAILLM(mock_llm_config_avian)
+
+    resp = await llm.acompletion(messages)
+    assert resp.choices[0].finish_reason == "stop"
+    assert resp.choices[0].message.content == resp_cont
+
+    await llm_general_chat_funcs_test(llm, prompt, messages, resp_cont)

--- a/tests/metagpt/provider/test_avian_api.py
+++ b/tests/metagpt/provider/test_avian_api.py
@@ -9,10 +9,13 @@
 
 import pytest
 from openai.types.chat import ChatCompletionChunk
+from openai.types.completion_usage import CompletionUsage
 
 from metagpt.configs.llm_config import LLMType
 from metagpt.provider.llm_provider_registry import create_llm_instance
 from metagpt.provider.openai_api import OpenAILLM
+from metagpt.utils.cost_manager import CostManager
+from metagpt.utils.token_counter import TOKEN_COSTS
 from tests.metagpt.provider.mock_llm_config import mock_llm_config_avian
 from tests.metagpt.provider.req_resp_const import (
     get_openai_chat_completion,
@@ -52,6 +55,42 @@ class TestAvianProvider:
         instance = OpenAILLM(mock_llm_config_avian)
         assert instance.model == "deepseek/deepseek-v3.2"
 
+    def test_avian_models_in_token_costs(self):
+        """Verify all Avian models have entries in TOKEN_COSTS for CostManager."""
+        avian_models = [
+            "deepseek/deepseek-v3.2",
+            "moonshotai/kimi-k2.5",
+            "z-ai/glm-5",
+            "minimax/minimax-m2.5",
+        ]
+        for model in avian_models:
+            assert model in TOKEN_COSTS, f"{model} missing from TOKEN_COSTS"
+            assert "prompt" in TOKEN_COSTS[model]
+            assert "completion" in TOKEN_COSTS[model]
+
+    def test_avian_cost_manager_update(self):
+        """Verify CostManager.update_cost tracks costs for Avian models."""
+        cost_manager = CostManager()
+        cost_manager.update_cost(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            model="deepseek/deepseek-v3.2",
+        )
+        assert cost_manager.total_prompt_tokens == 1000
+        assert cost_manager.total_completion_tokens == 500
+        assert cost_manager.total_cost > 0
+
+    def test_avian_update_costs_via_base_llm(self):
+        """Verify _update_costs delegates to CostManager properly."""
+        llm = OpenAILLM(mock_llm_config_avian)
+        llm.cost_manager = CostManager()
+        usage = CompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+        llm._update_costs(usage)
+        costs = llm.get_costs()
+        assert costs.total_prompt_tokens == 100
+        assert costs.total_completion_tokens == 50
+        assert costs.total_cost > 0
+
 
 async def mock_avian_acompletions_create(self, stream: bool = False, **kwargs) -> ChatCompletionChunk:
     if stream:
@@ -70,6 +109,7 @@ async def test_avian_acompletion(mocker):
     mocker.patch("openai.resources.chat.completions.AsyncCompletions.create", mock_avian_acompletions_create)
 
     llm = OpenAILLM(mock_llm_config_avian)
+    llm.cost_manager = CostManager()
 
     resp = await llm.acompletion(messages)
     assert resp.choices[0].finish_reason == "stop"


### PR DESCRIPTION
## Features

Add [Avian](https://avian.io) as an OpenAI-compatible LLM provider. Avian provides access to multiple frontier models through a unified API endpoint at `https://api.avian.io/v1` with Bearer token authentication (`AVIAN_API_KEY`).

### Supported Models

| Model | Context | Max Output | Input $/1M | Output $/1M |
|-------|---------|-----------|------------|-------------|
| `deepseek/deepseek-v3.2` | 164K | 65K | $0.26 | $0.38 |
| `moonshotai/kimi-k2.5` | 131K | 8K | $0.45 | $2.20 |
| `z-ai/glm-5` | 131K | 16K | $0.30 | $2.55 |
| `minimax/minimax-m2.5` | 1M | 1M | $0.30 | $1.10 |

### Changes

- **`metagpt/configs/llm_config.py`**: Add `LLMType.AVIAN` enum value
- **`metagpt/provider/openai_api.py`**: Register `LLMType.AVIAN` with `OpenAILLM` (standard OpenAI-compatible provider)
- **`metagpt/utils/token_counter.py`**: Add token costs (`TOKEN_COSTS`) and context lengths (`TOKEN_MAX`) for all Avian models
- **`config/examples/avian-deepseek-v3.2.yaml`**: Example configuration file
- **`tests/metagpt/provider/mock_llm_config.py`**: Add mock config for Avian
- **`tests/metagpt/provider/test_avian_api.py`**: Unit tests (provider registration, client config, mock completions)

### Usage

```yaml
# config/config2.yaml
llm:
  api_type: "avian"
  base_url: "https://api.avian.io/v1"
  api_key: "YOUR_AVIAN_API_KEY"
  model: "deepseek/deepseek-v3.2"
```

This follows the same pattern as other OpenAI-compatible providers (DeepSeek, SiliconFlow, OpenRouter, Llama API, etc.) — no new dependencies required.

cc @garylin2099 @better629