### PR TITLE
fix: add password_auth_callback to Chainlit example app (#2070)

### DIFF
--- a/examples/ui_with_chainlit/README.md
+++ b/examples/ui_with_chainlit/README.md
@@ -19,6 +19,8 @@ chainlit run app.py
 
 - Now go to: http://localhost:8000
 
+- Default login: `admin` / `admin` (configurable via `CHAINLIT_USERNAME` and `CHAINLIT_PASSWORD` environment variables).
+
 - Select,
   - `Create a 2048 game`
   - `Write a cli Blackjack Game`

--- a/examples/ui_with_chainlit/app.py
+++ b/examples/ui_with_chainlit/app.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import chainlit as cl
+import os
 from init_setup import ChainlitEnv
 
 from metagpt.roles import (
@@ -11,6 +12,21 @@ from metagpt.roles import (
     QaEngineer,
 )
 from metagpt.team import Team
+
+
+# https://docs.chainlit.io/concepts/authentication
+@cl.password_auth_callback
+def auth_callback(username: str, password: str) -> cl.User | None:
+    """Validate credentials from environment variables.
+
+    Reads CHAINLIT_USERNAME and CHAINLIT_PASSWORD from the environment.
+    Falls back to a simple demo credential if neither is set.
+    """
+    expected_user = os.environ.get("CHAINLIT_USERNAME", "admin")
+    expected_pass = os.environ.get("CHAINLIT_PASSWORD", "admin")
+    if username == expected_user and password == expected_pass:
+        return cl.User(identifier=username)
+    return None
 
 
 # https://docs.chainlit.io/concepts/starters

--- a/examples/ui_with_chainlit/app.py
+++ b/examples/ui_with_chainlit/app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import chainlit as cl

--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -1,0 +1,18 @@
+"""Override the global autouse llm_mock fixture for tests in examples/.
+
+The global tests/conftest.py defines an autouse=True fixture `llm_mock`
+that initialises MockLLM (and its underlying AsyncHttpxClientWrapper).
+Some CI runners set HTTP_PROXY/HTTPS_PROXY environment variables that
+cause httpx to reject the proxy scheme, breaking every test in this
+directory.
+
+Since our example tests are self-contained (stdlib-only with module stubs)
+and don't need LLM mocking, we override the fixture with a noop.
+"""
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def llm_mock():
+    """Noop override — these tests don't need LLM mocking."""
+    yield None

--- a/tests/examples/test_password_auth_callback.py
+++ b/tests/examples/test_password_auth_callback.py
@@ -1,0 +1,125 @@
+"""Standalone test for the password_auth_callback added in #2070.
+
+Uses sys.modules stubs to avoid pulling in the chainlit package
+(which requires PyYAML, literalai, syncer, watchfiles, ... and a running DB).
+
+Run:
+    python3 tests/examples/test_password_auth_callback.py
+"""
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+def _load_app_module():
+    """Load examples/ui_with_chainlit/app.py with chainlit stubbed out."""
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    app_path = os.path.join(repo_root, "examples", "ui_with_chainlit", "app.py")
+
+    captured = {"password_auth_callback": None, "set_chat_profiles": None}
+
+    class _ClUser:
+        def __init__(self, identifier):
+            self.identifier = identifier
+
+    class _ChainlitStub:
+        User = _ClUser
+
+        @staticmethod
+        def password_auth_callback(fn):
+            captured["password_auth_callback"] = fn
+            return fn
+
+        @staticmethod
+        def set_chat_profiles(fn):
+            captured["set_chat_profiles"] = fn
+            return fn
+
+        @staticmethod
+        def on_message(fn):
+            return fn
+
+        # The remaining attributes are accessed as class namespaces at import
+        # time (e.g. `cl.ChatProfile`, `cl.Starter`, `cl.Message`); they don't
+        # need real implementations, just a usable class object.
+        class ChatProfile: ...
+        class Starter: ...
+        class Message: ...
+
+    sys.modules["chainlit"] = _ChainlitStub
+    sys.modules["init_setup"] = mock.MagicMock()
+    sys.modules.setdefault("metagpt", mock.MagicMock())
+    sys.modules.setdefault("metagpt.roles", mock.MagicMock())
+    sys.modules.setdefault("metagpt.team", mock.MagicMock())
+
+    spec = importlib.util.spec_from_file_location("_app_under_test", app_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, captured
+
+
+_callback = None
+
+
+def setUpModule():
+    global _callback
+    _, captured = _load_app_module()
+    _callback = captured["password_auth_callback"]
+    assert _callback is not None, "password_auth_callback was not registered by app.py"
+
+
+class TestPasswordAuthCallback(unittest.TestCase):
+    def _call(self, *args):
+        """Invoke the module-level callback directly (not through self)."""
+        return _callback(*args)
+
+    def test_correct_credentials_returns_user(self):
+        """Matching username/password returns a cl.User with that identifier."""
+        with mock.patch.dict(
+            os.environ, {"CHAINLIT_USERNAME": "alice", "CHAINLIT_PASSWORD": "wonderland"}
+        ):
+            result = self._call("alice", "wonderland")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.identifier, "alice")
+
+    def test_wrong_password_returns_none(self):
+        with mock.patch.dict(
+            os.environ, {"CHAINLIT_USERNAME": "alice", "CHAINLIT_PASSWORD": "wonderland"}
+        ):
+            self.assertIsNone(self._call("alice", "wrong"))
+
+    def test_wrong_username_returns_none(self):
+        with mock.patch.dict(
+            os.environ, {"CHAINLIT_USERNAME": "alice", "CHAINLIT_PASSWORD": "wonderland"}
+        ):
+            self.assertIsNone(self._call("mallory", "wonderland"))
+
+    def test_empty_credentials_returns_none(self):
+        with mock.patch.dict(
+            os.environ, {"CHAINLIT_USERNAME": "alice", "CHAINLIT_PASSWORD": "wonderland"}
+        ):
+            self.assertIsNone(self._call("", ""))
+            self.assertIsNone(self._call("alice", ""))
+            self.assertIsNone(self._call("", "wonderland"))
+
+    def test_falls_back_to_default_when_env_unset(self):
+        """When env vars are unset, the default admin/admin must work."""
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("CHAINLIT_USERNAME", "CHAINLIT_PASSWORD")}
+        with mock.patch.dict(os.environ, env, clear=True):
+            result = self._call("admin", "admin")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.identifier, "admin")
+
+    def test_default_rejected_when_env_set(self):
+        """If env is set to non-admin values, admin/admin must NOT succeed."""
+        with mock.patch.dict(
+            os.environ, {"CHAINLIT_USERNAME": "alice", "CHAINLIT_PASSWORD": "wonderland"}
+        ):
+            self.assertIsNone(self._call("admin", "admin"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Fixes #2070 — adds a `@cl.password_auth_callback` function to `examples/ui_with_chainlit/app.py` so the Chainlit example UI has a working login page.

## Changes

- **`examples/ui_with_chainlit/app.py`** — Added `@cl.password_auth_callback` that reads credentials from `CHAINLIT_USERNAME` / `CHAINLIT_PASSWORD` environment variables, falling back to `admin`/`admin` defaults. Returns a `cl.User` on match, `None` on mismatch.

- **`examples/ui_with_chainlit/README.md`** — Updated usage section to document the default login (`admin`/`admin`) and the configurable env vars.

- **`tests/examples/test_password_auth_callback.py`** — Self-contained, zero-dependency test (stdlib only). Stubs the `chainlit`, `metagpt`, and `init_setup` modules so it runs without a full Python environment. 6 test cases covering:
  - Valid credentials → `cl.User` with correct identifier
  - Wrong password → `None`
  - Wrong username → `None`
  - Empty credentials → `None`
  - Fallback `admin`/`admin` when env vars unset
  - Default credentials rejected when env vars set to different values

## Testing

```
$ python3 tests/examples/test_password_auth_callback.py
----------------------------------------------------------------------
Ran 6 tests in 0.012s
OK
```
