### PR TITLE
fix(terminal): yield single-line buffers so end marker is observed

### DIFF
--- a/metagpt/tools/libs/terminal.py
+++ b/metagpt/tools/libs/terminal.py
@@ -152,12 +152,39 @@ class Terminal:
             # Read the output until the unique marker is found.
             # We read bytes directly from stdout instead of text because when reading text,
             # '\r' is changed to '\n', resulting in excessive output.
+            # Keep an incomplete trailing fragment in `tmp` until we see a
+            # newline (or EOF). Do NOT use `*lines, tmp = splitlines(True)` —
+            # when the buffer is a single newline-terminated line, that unpack
+            # moves the only line into `tmp` and never yields it, so the
+            # end-of-command marker is never observed and run_command hangs
+            # forever on Linux/WSL2 (#2110).
             tmp = b""
             while True:
-                output = tmp + await self.process.stdout.read(1)
-                if not output:
-                    continue
-                *lines, tmp = output.splitlines(True)
+                chunk = await self.process.stdout.read(1)
+                if not chunk:
+                    # EOF: process any residual bytes still in the buffer.
+                    if not tmp:
+                        continue
+                    lines, tmp = [tmp], b""
+                else:
+                    output = tmp + chunk
+                    if output.endswith(b"
+") or output.endswith(b""):
+                        lines, tmp = [output], b""
+                    else:
+                        # Incomplete line — wait for more bytes.
+                        # If the buffer contains multiple lines, flush complete ones.
+                        parts = output.splitlines(True)
+                        if len(parts) > 1:
+                            *lines, tmp = parts
+                        else:
+                            # Single incomplete fragment (no trailing newline yet).
+                            if parts and (parts[0].endswith(b"
+") or parts[0].endswith(b"")):
+                                lines, tmp = parts, b""
+                            else:
+                                tmp = output
+                                continue
                 for line in lines:
                     line = line.decode(errors="ignore")
                     ix = line.rfind(END_MARKER_VALUE)

--- a/tests/metagpt/tools/libs/test_terminal.py
+++ b/tests/metagpt/tools/libs/test_terminal.py
@@ -20,3 +20,28 @@ async def test_terminal():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-s"])
+
+
+def test_splitlines_unpack_does_not_hide_end_marker():
+    """Regression for #2110: a single newline-terminated buffer must be yielded.
+
+    The old `*lines, tmp = buf.splitlines(True)` idiom moved a lone complete
+    line into `tmp`, so the end-of-command marker was never observed.
+    """
+    from metagpt.utils.report import END_MARKER_VALUE
+
+    # Simulate the buffer state when the marker arrives as the only line.
+    buf = END_MARKER_VALUE.encode()  # already ends with \n
+    parts = buf.splitlines(True)
+    assert len(parts) == 1
+    # Correct handling: treat a trailing-newline buffer as a complete line.
+    if parts[0].endswith(b"\n") or parts[0].endswith(b"\r"):
+        lines, tmp = parts, b""
+    else:
+        *lines, tmp = parts if len(parts) > 1 else ([], parts[0] if parts else b"")
+    assert lines and END_MARKER_VALUE.encode() in lines[0] or END_MARKER_VALUE in lines[0].decode(errors="ignore")
+    assert tmp == b""
+    # Old broken behavior would leave lines empty:
+    *broken_lines, broken_tmp = parts
+    assert broken_lines == []
+    assert broken_tmp == parts[0]


### PR DESCRIPTION
## Summary
`Terminal.run_command()` hung forever on Linux/WSL2 because `_read_and_process_output` used:

```python
*lines, tmp = output.splitlines(True)
```

When the buffer is a **single newline-terminated line** (the common case for the end-of-command marker), that unpack moves the only line into `tmp` and leaves `lines` empty — so the marker check never runs and the loop waits for a next byte that never arrives.

Every `Engineer2._think()` starts with `await self.terminal.run_command("pwd")`, so this deadlocks the agent before any LLM call.

## Change
Treat a buffer that already ends with `\n`/`\r` as a complete line to yield. Keep incomplete fragments in `tmp` only when they lack a trailing newline.

## Test plan
- [x] Unit regression documenting the broken unpack vs correct handling of a lone marker line
- Manual: `await Terminal().run_command("pwd")` returns promptly on Linux/WSL2

Fixes #2110
