### PR TITLE
fix: honor send_to in Team.run_project

### DIFF
--- a/metagpt/team.py
+++ b/metagpt/team.py
@@ -104,7 +104,7 @@ class Team(BaseModel):
         self.idea = idea
 
         # Human requirement.
-        self.env.publish_message(Message(content=idea))
+        self.env.publish_message(Message(content=idea, send_to=send_to))
 
     def start_project(self, idea, send_to: str = ""):
         """

--- a/tests/metagpt/test_team.py
+++ b/tests/metagpt/test_team.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # @Desc   : unittest of team
 
+from metagpt.const import MESSAGE_ROUTE_TO_ALL
 from metagpt.roles.project_manager import ProjectManager
 from metagpt.team import Team
 
@@ -11,3 +12,22 @@ def test_team():
     company.hire([ProjectManager()])
 
     assert len(company.env.roles) == 1
+
+
+def test_run_project_send_to():
+    company = Team(use_mgx=False)
+
+    company.run_project("A test idea", send_to="Alex")
+
+    message = company.env.history.get(k=1)[0]
+    assert message.content == "A test idea"
+    assert message.send_to == {"Alex"}
+
+
+def test_run_project_broadcast_by_default():
+    company = Team(use_mgx=False)
+
+    company.run_project("A test idea")
+
+    message = company.env.history.get(k=1)[0]
+    assert message.send_to == {MESSAGE_ROUTE_TO_ALL}


### PR DESCRIPTION
## Summary

Pass the `send_to` argument from `Team.run_project()` to the initial `Message`.

Previously, the method accepted a recipient but did not forward it, so workflows that need to route the initial requirement to a specific role could remain idle. For example, `examples/debate_simple.py` passes `send_to="Alex"`, but neither debater reacts when the initial message is broadcast without the intended recipient.

## Root cause

`Team.run_project()` constructed the initial message with only `content=idea`, silently dropping its `send_to` parameter.

## Tests

- Added coverage for routing the initial project message to a specified role.
- Added coverage for preserving the existing broadcast behavior when no recipient is supplied.
- `python -m pytest -q tests/metagpt/test_team.py` (3 passed).
