### PR TITLE
fix(token_counter): clamp max completion tokens to non-negative and normalize model names

### DIFF
--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -536,10 +536,15 @@ def get_max_completion_tokens(messages: list[dict], model: str, default: int) ->
     Args:
         messages: A list of messages.
         model: The model name.
+        default: Default token count if model is not recognized.
 
     Returns:
-        The maximum number of completion tokens.
+        The maximum number of completion tokens (clamped to non-negative).
     """
-    if model not in TOKEN_MAX:
+    target_model = model
+    if target_model not in TOKEN_MAX and "/" in target_model:
+        target_model = target_model.split("/", 1)[-1]
+    if target_model not in TOKEN_MAX:
         return default
-    return TOKEN_MAX[model] - count_message_tokens(messages, model) - 1
+    available = TOKEN_MAX[target_model] - count_message_tokens(messages, target_model) - 1
+    return max(0, available)

--- a/metagpt/utils/token_counter.py
+++ b/metagpt/utils/token_counter.py
@@ -9,7 +9,8 @@ ref2: https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_
 ref3: https://github.com/Significant-Gravitas/Auto-GPT/blob/master/autogpt/llm/token_counter.py
 ref4: https://github.com/hwchase17/langchain/blob/master/langchain/chat_models/openai.py
 ref5: https://ai.google.dev/models/gemini
-"""
+from __future__ import annotations
+
 import anthropic
 import tiktoken
 

--- a/tests/metagpt/utils/test_token_counter.py
+++ b/tests/metagpt/utils/test_token_counter.py
@@ -69,5 +69,21 @@ def test_count_string_tokens_gpt_4():
     assert count_output_tokens(string, model="gpt-4-0314") == 4
 
 
+def test_get_max_completion_tokens():
+    from metagpt.utils.token_counter import get_max_completion_tokens
+
+    messages = [{"role": "user", "content": "Hello"}]
+    # gpt-4 has max 8192 tokens
+    max_tokens = get_max_completion_tokens(messages, model="gpt-4", default=4096)
+    assert max_tokens > 0
+
+    # test unknown model falls back to default
+    assert get_max_completion_tokens(messages, model="unknown_model", default=2048) == 2048
+
+    # test provider-prefixed model normalization
+    assert get_max_completion_tokens(messages, model="openai/gpt-4o", default=1000) > 100000
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-s"])
+


### PR DESCRIPTION
## Summary

Improves `get_max_completion_tokens()` in `metagpt.utils.token_counter`:
- Clamps the returned maximum completion token count to non-negative (`max(0, ...)`), preventing negative token values when input messages reach or exceed the context limit.
- Adds provider prefix stripping (e.g. `openai/gpt-4o`) for model name resolution in `TOKEN_MAX`.
- Added unit tests in `tests/metagpt/utils/test_token_counter.py`.

## Motivation

When message history exceeds the context budget or fills the window, `get_max_completion_tokens()` previously returned negative values (such as `-10`), which led to API validation errors when passed as `max_tokens` to downstream LLM providers. Additionally, provider-prefixed model names were not matched against known model context configurations.

## Changes

- `metagpt/utils/token_counter.py`: Normalized model name lookup and clamped return value to `>= 0`.
- `tests/metagpt/utils/test_token_counter.py`: Added `test_get_max_completion_tokens`.

## Tests

- Added `test_get_max_completion_tokens` verifying positive bounds, default fallback, and provider prefix normalization.
