### PR TITLE
docs: fix broken ProjectRepo import, dead link and typos

### DIFF
--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -41,12 +41,13 @@ metagpt "创建一个 2048 游戏"  # 这将在 ./workspace 创建一个仓库
 或者您可以将其作为库使用
 
 ```python
-from metagpt.software_company import generate_repo, ProjectRepo
+from metagpt.software_company import generate_repo
+from metagpt.utils.project_repo import ProjectRepo
 repo: ProjectRepo = generate_repo("创建一个 2048 游戏")  # 或 ProjectRepo("<路径>")
 print(repo)  # 它将打印出仓库结构及其文件
 ```
 
-详细的安装请参考 [cli_install](https://docs.deepwisdom.ai/guide/get_started/installation.html#install-stable-version)
+详细的安装请参考 [cli_install](https://docs.deepwisdom.ai/main/zh/guide/get_started/installation.html#install-stable-version)
 
 ### Docker安装
 > 注意：在Windows中，你需要将 "/opt/metagpt" 替换为Docker具有创建权限的目录，比如"D:\Users\x\metagpt"

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -135,7 +135,7 @@ https://github.com/user-attachments/assets/888cb169-78c3-4a42-9d62-9d90ed3928c9
   - [MetaGPT Guide d'utilisation et de développement | Agent 101](https://docs.deepwisdom.ai/main/en/guide/tutorials/agent_101.html)
   - [MetaGPT Guide d'utilisation et de développement | MultiAgent 101](https://docs.deepwisdom.ai/main/en/guide/tutorials/multi_agent_101.html)
 - 🧑‍💻 Contribution
-  - [Élaborer une feuille de route](docs/ROADMAP.md)
+  - [Élaborer une feuille de route](ROADMAP.md)
 - 🔖 Cas d'usage
   - [Interprète des données](https://docs.deepwisdom.ai/main/en/guide/use_cases/agent/interpreter/intro.html)
   - [Débat](https://docs.deepwisdom.ai/main/en/guide/use_cases/multi_agent/debate.html)

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -100,7 +100,8 @@ metagpt "Create a 2048 game"  #  ceci créera un repo dans ./workspace
 ou l'utiliser comme bibliothèque
 
 ```python
-from metagpt.software_company import generate_repo, ProjectRepo
+from metagpt.software_company import generate_repo
+from metagpt.utils.project_repo import ProjectRepo
 repo: ProjectRepo = generate_repo("Create a 2048 game")  # ou ProjectRepo("<path>")
 print(repo)  # il affichera la structure du repo avec les fichiers
 ```

--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -62,7 +62,8 @@ metagpt "2048ゲームを作成する"  # これにより ./workspace にリポ�
 または、ライブラリとして使用することもできます
 
 ```python
-from metagpt.software_company import generate_repo, ProjectRepo
+from metagpt.software_company import generate_repo
+from metagpt.utils.project_repo import ProjectRepo
 repo: ProjectRepo = generate_repo("2048ゲームを作成する")  # または ProjectRepo("<パス>")
 print(repo)  # リポジトリの構造とファイルを出力します
 ```
@@ -78,7 +79,7 @@ Chromium のダウンロードをスキップすることができます。
   npm install @mermaid-js/mermaid-cli
   ```
 
-- config.yml に mmdc のコンフィグを記述するのを忘れないこと
+- config2.yaml に mmdc のコンフィグを記述するのを忘れないこと
 
   ```yml
   puppeteer_config: "./config/puppeteer-config.json"
@@ -98,7 +99,7 @@ Chromium のダウンロードをスキップすることができます。
 
     - **必要なブラウザのインストール**
 
-    PDF変換をサポートするには、Chrominumをインストールしてください。
+    PDF変換をサポートするには、Chromiumをインストールしてください。
 
     ```bash
     playwright install --with-deps chromium

--- a/docs/install/cli_install.md
+++ b/docs/install/cli_install.md
@@ -45,7 +45,7 @@ sudo npm install -g @mermaid-js/mermaid-cli
   npm install @mermaid-js/mermaid-cli
   ```
 
-- don't forget to the configuration for mmdc path in config.yml
+- don't forget to set the configuration for the mmdc path in config2.yaml
 
   ```yaml
   mermaid:
@@ -66,7 +66,7 @@ sudo npm install -g @mermaid-js/mermaid-cli
 
     - **Install the Required Browsers**
 
-    to support PDF conversion, please install Chrominum.
+    to support PDF conversion, please install Chromium.
 
     ```bash
     playwright install --with-deps chromium
@@ -90,7 +90,7 @@ sudo npm install -g @mermaid-js/mermaid-cli
 
     - **Use your own Browsers**
 
-    pyppeteer allows you use installed browsers,  please set the following envirment
+    pyppeteer allows you use installed browsers,  please set the following environment
     
     ```bash
     export PUPPETEER_EXECUTABLE_PATH = /path/to/your/chromium or edge or chrome

--- a/metagpt/ext/sela/experimenter.py
+++ b/metagpt/ext/sela/experimenter.py
@@ -129,7 +129,7 @@ class Experimenter(DataInterpreter):
         return score_dict
 
     @model_validator(mode="after")
-    def set_plan_and_tool(self) -> "Interpreter":
+    def set_plan_and_tool(self) -> "DataInterpreter":
         if self.planner.plan.goal != "":
             self.set_actions([WriteAnalysisCode])
             self._set_state(0)

--- a/metagpt/roles/di/data_interpreter.py
+++ b/metagpt/roles/di/data_interpreter.py
@@ -47,7 +47,7 @@ class DataInterpreter(Role):
     user_requirement: str = ""
 
     @model_validator(mode="after")
-    def set_plan_and_tool(self) -> "Interpreter":
+    def set_plan_and_tool(self) -> "DataInterpreter":
         self._set_react_mode(react_mode=self.react_mode, max_react_loop=self.max_react_loop, auto_run=self.auto_run)
         self.use_plan = (
             self.react_mode == "plan_and_act"

--- a/metagpt/strategy/tot.py
+++ b/metagpt/strategy/tot.py
@@ -269,7 +269,6 @@ class TreeofThought(BaseModel):
 
         Args:
             init_prompt (str): The initial prompt for the solver.
-            strategy (str): The strategy to use for solving.
 
         Returns:
             Any: The solution obtained using the selected strategy.


### PR DESCRIPTION
## Summary
All verified at HEAD:

- **README_CN/JA/FR**: `from metagpt.software_company import generate_repo, ProjectRepo` raises `ImportError` — `software_company.py` has no `ProjectRepo`. The English README imports it from `metagpt.utils.project_repo`; the three translations now do the same.
- **README_CN**: the cli_install link was missing the `/main/zh` docs segment and returned HTTP 500; sibling links in the same file use `/main/zh/`.
- **install/cli_install.md + README_JA**: `config.yml` → `config2.yaml` (the only config file that exists), `Chrominum` → `Chromium`, `envirment` → `environment`, added missing verb.
- **data_interpreter.py / sela experimenter.py**: return annotation referenced a nonexistent `Interpreter` class → `DataInterpreter`.
- **tot.py**: `solve()` docstring documented a `strategy` arg it doesn't take (copied from `_initialize_solver`).