### PR TITLE
fix(terminal): process newline-terminated markers

### DIFF
--- a/metagpt/tools/libs/terminal.py
+++ b/metagpt/tools/libs/terminal.py
@@ -157,7 +157,11 @@ class Terminal:
                 output = tmp + await self.process.stdout.read(1)
                 if not output:
                     continue
-                *lines, tmp = output.splitlines(True)
+                lines = output.splitlines(True)
+                if output.endswith(b"\n"):
+                    tmp = b""
+                else:
+                    *lines, tmp = lines
                 for line in lines:
                     line = line.decode(errors="ignore")
                     ix = line.rfind(END_MARKER_VALUE)

--- a/tests/metagpt/tools/libs/test_terminal.py
+++ b/tests/metagpt/tools/libs/test_terminal.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from metagpt.const import DATA_PATH, METAGPT_ROOT
@@ -8,14 +10,17 @@ from metagpt.tools.libs.terminal import Terminal
 async def test_terminal():
     terminal = Terminal()
 
-    await terminal.run_command(f"cd {METAGPT_ROOT}")
-    output = await terminal.run_command("pwd")
-    assert output.strip() == str(METAGPT_ROOT)
+    try:
+        await asyncio.wait_for(terminal.run_command(f"cd {METAGPT_ROOT}"), timeout=5)
+        output = await asyncio.wait_for(terminal.run_command("pwd"), timeout=5)
+        assert output.strip() == str(METAGPT_ROOT)
 
-    # pwd now should be METAGPT_ROOT, cd data should land in DATA_PATH
-    await terminal.run_command("cd data")
-    output = await terminal.run_command("pwd")
-    assert output.strip() == str(DATA_PATH)
+        # pwd now should be METAGPT_ROOT, cd data should land in DATA_PATH
+        await asyncio.wait_for(terminal.run_command("cd data"), timeout=5)
+        output = await asyncio.wait_for(terminal.run_command("pwd"), timeout=5)
+        assert output.strip() == str(DATA_PATH)
+    finally:
+        await terminal.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Features**

- Process a complete stdout line immediately when its newline arrives instead of retaining it as an incomplete buffer.
- Add bounded waits and deterministic process cleanup to the existing terminal integration test.
- Fixes #2110. This is a smaller replacement for the self-closed #2111.

**Feature Docs**

Not applicable.

**Influence**

`Terminal.run_command()` no longer waits forever after bash emits the end-of-command marker as the final newline-terminated line.

**Result**

- Before: the real `Terminal.run_command("pwd")` path timed out after 3 seconds.
- After: the same bash-backed smoke test returned `"/tmp\n"` immediately.
- `ruff check metagpt/tools/libs/terminal.py tests/metagpt/tools/libs/test_terminal.py`
- `ruff format --check metagpt/tools/libs/terminal.py tests/metagpt/tools/libs/test_terminal.py`
- `git diff --check`

**Other**

The regression test uses `asyncio.wait_for` so a future marker-processing regression fails within five seconds instead of hanging the test job.